### PR TITLE
📖 DOC: kicks guide off

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ Showing two examples each...
 * 🐛 BUG: fixes typo on About
 * 📖 DOC: edits SSH instructions
 * 📖 DOC: adds local env setup guide
-* 👌 IMPROVE: tweaks logo SVG animation
-* 👌 IMPROVE: reorders Checkout flow
+* ⚡ IMPROVE: tweaks logo SVG animation
+* ⚡ IMPROVE: reorders Checkout flow
 * 📦 NEW: adds CTA component
 * 📦 NEW: creates new Teacher data model
 * 🚀 RELEASE: ships checkout feature

--- a/README.md
+++ b/README.md
@@ -28,4 +28,5 @@ Showing two examples each...
 
 ## automating emojis in terminal
 
-Maybe a simple CLI would be nice...
+Maybe a simple CLI would be nice...boom!
+https://github.com/sodiumhalogenteam/git-emoji

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Emoji Commit Types - by Sodium Halogen
 
-Enspired by [ahmadawais](https://github.com/ahmadawais/create-guten-block).
+Enspired by [ahmadawais](https://github.com/ahmadawais/create-guten-block) and [parmentf](https://gist.github.com/parmentf/035de27d6ed1dce0b36a).
 
 Adding a key for emoji infused commits. Helping categorize the types of commits.
 
@@ -11,18 +11,20 @@ We've found this to be a great way to keep our commits concise.
 Format: `[emoji] SINGULAR_CAPS_TITLE: present tense commit message`
 Showing two examples each...
 
-* 💅 STYLE: adds styles to Header dropdowns
-* 💅 STYLE: tweaks styles of contact form
 * 🐛 BUG: fixes props assignment on MenuToggle
 * 🐛 BUG: fixes typo on About
-* 👌 IMPROVE: tweaks logo SVG animation
-* 👌 IMPROVE: reorders Checkout flow
-* 🚀 RELEASE: ships checkout feature
-* 🚀 RELEASE: releases german translation
-* 📦 NEW: adds CTA component
-* 📦 NEW: creates new Teacher data model
 * 📖 DOC: edits SSH instructions
 * 📖 DOC: adds local env setup guide
+* 👌 IMPROVE: tweaks logo SVG animation
+* 👌 IMPROVE: reorders Checkout flow
+* 📦 NEW: adds CTA component
+* 📦 NEW: creates new Teacher data model
+* 🚀 RELEASE: ships checkout feature
+* 🚀 RELEASE: releases german translation
+* 💅 STYLE: adds styles to Header dropdowns
+* 💅 STYLE: tweaks styles of contact form
+* ✅ TEST: adds checkout form test
+* ✅ TEST: adds add-to-cart test
 
 ## automating emojis in terminal
 

--- a/README.md
+++ b/README.md
@@ -29,4 +29,4 @@ Showing two examples each...
 ## automating emojis in terminal
 
 Maybe a simple CLI would be nice...boom!
-https://github.com/sodiumhalogenteam/git-emoji
+https://github.com/sodiumhalogenteam/git-emoji-commit

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Emoji Commit Types - by Sodium Halogen
+
 Enspired by [ahmadawais](https://github.com/ahmadawais/create-guten-block).
 
 Adding a key for emoji infused commits. Helping categorize the types of commits.
@@ -11,14 +12,18 @@ Format: `[emoji] CAPS_TITLE: present tense commit message`
 Showing two examples each...
 
 * 💅 STYLES: adds styles to Header dropdowns
-* 💅 STYLES: tweaks 
+* 💅 STYLES: tweaks
 * 🐛 BUG: fixes props assignment on MenuToggle
 * 🐛 BUG: fixes typo on About
 * 👌 IMPROVE: tweaks logo SVG animation
 * 👌 IMPROVE: reorders Checkout flow
-* 🚀 RELEASE: adds 
-* 🚀 RELEASE: adds 
-* 📦 NEW: adds 
-* 📦 NEW: adds 
+* 🚀 RELEASE: adds
+* 🚀 RELEASE: adds
+* 📦 NEW: adds
+* 📦 NEW: adds
 * 📖 DOC: edits SSH insturctions
 * 📖 DOC: adds local setup guide
+
+## automating emojis in terminal
+
+Maybe a simple CLI would be nice...

--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ We've found this to be a great way to keep our commits concise.
 
 ## key w/ commit style/examples
 
-Format: `[emoji] CAPS_TITLE: present tense commit message`
+Format: `[emoji] SINGULAR_CAPS_TITLE: present tense commit message`
 Showing two examples each...
 
-* 💅 STYLES: adds styles to Header dropdowns
-* 💅 STYLES: tweaks styles of contact form
+* 💅 STYLE: adds styles to Header dropdowns
+* 💅 STYLE: tweaks styles of contact form
 * 🐛 BUG: fixes props assignment on MenuToggle
 * 🐛 BUG: fixes typo on About
 * 👌 IMPROVE: tweaks logo SVG animation

--- a/README.md
+++ b/README.md
@@ -12,17 +12,17 @@ Format: `[emoji] CAPS_TITLE: present tense commit message`
 Showing two examples each...
 
 * 💅 STYLES: adds styles to Header dropdowns
-* 💅 STYLES: tweaks
+* 💅 STYLES: tweaks styles of contact form
 * 🐛 BUG: fixes props assignment on MenuToggle
 * 🐛 BUG: fixes typo on About
 * 👌 IMPROVE: tweaks logo SVG animation
 * 👌 IMPROVE: reorders Checkout flow
-* 🚀 RELEASE: adds
-* 🚀 RELEASE: adds
-* 📦 NEW: adds
-* 📦 NEW: adds
-* 📖 DOC: edits SSH insturctions
-* 📖 DOC: adds local setup guide
+* 🚀 RELEASE: ships checkout feature
+* 🚀 RELEASE: releases german translation
+* 📦 NEW: adds CTA component
+* 📦 NEW: creates new Teacher data model
+* 📖 DOC: edits SSH instructions
+* 📖 DOC: adds local env setup guide
 
 ## automating emojis in terminal
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
-# emoji-commit-types
+# Emoji Commit Types - by Sodium Halogen
+Enspired by [ahmadawais](https://github.com/ahmadawais/create-guten-block).
+
+Adding a key for emoji infused commits. Helping categorize the types of commits.
+
+We've found this to be a great way to keep our commits concise.
+
+## key w/ commit style/examples
+
+Format: `[emoji] CAPS_TITLE: present tense commit message`
+Showing two examples each...
+
+* 💅 STYLES: adds styles to Header dropdowns
+* 💅 STYLES: tweaks 
+* 🐛 BUG: fixes props assignment on MenuToggle
+* 🐛 BUG: fixes typo on About
+* 👌 IMPROVE: tweaks logo SVG animation
+* 👌 IMPROVE: reorders Checkout flow
+* 🚀 RELEASE: adds 
+* 🚀 RELEASE: adds 
+* 📦 NEW: adds 
+* 📦 NEW: adds 
+* 📖 DOC: edits SSH insturctions
+* 📖 DOC: adds local setup guide

--- a/emoji-commit.sh
+++ b/emoji-commit.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+echo "select the operation ************  1)operation 1 2)operation 2 3)operation 3 4)operation 4 "
+
+read n
+case $n in
+    1) commands for opn 1;;
+    2) commands for opn 2;;
+    3) commands for opn 3;;
+    4) commands for  opn 4;;
+    *) invalid option;;
+esac


### PR DESCRIPTION
To be the first to say, wanting to keep our git-ing easy, helpful, and achievable by all devs. Let's explore better ways.

I don't want to merge this in just yet. Still thinking through this...

What if instead:
* `💅 STYLES: adds styles to checkout page form`
* `📖 DOC: adds setup guide`

we do this:
* `💅 STYLES: checkout page form`
* `📖 DOC: setup guide`

Same context, but less to type, and follows the best practice of Git present tense.
Thoughts?